### PR TITLE
feat: add five new services, shared utils, and bug fixes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,40 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Commands
+
+```bash
+npm run dev          # Run CLI via tsx (no build needed)
+npm run build        # Compile to dist/ via tsup (CJS output)
+npm run start        # Run compiled dist/index.cjs
+```
+
+There is no test suite. Development uses `npm run dev` to exercise CLI commands directly.
+
+## Architecture
+
+This is a TypeScript CLI tool (`@palr-dev/devstack-cli`) that generates and manages Docker Compose files for local development. It is published to npm as `devstack` binary and has no runtime UI — everything runs in the terminal via [commander](https://github.com/tj/commander.js).
+
+### Data flow for every command
+
+1. **`src/index.ts`** — entry point; registers all `commander` commands and subcommands, then calls the appropriate `run*Config` function.
+2. **`src/functions/run*Config.ts`** — one file per command. Each reads `devstack.config.json` from `process.cwd()` via `src/utils/config.ts`, mutates it or acts on it, then either writes it back or shells out to Docker.
+3. **`src/utils/config.ts`** — thin helpers: `readConfig()`, `writeConfig()`, `convertToYAML()`. All config I/O goes through here.
+4. **`src/models/devstack-config.ts`** — all TypeScript interfaces (`DevStackConfig`, `DevStackServices`, `PostgresServiceConfig`, `RedisServiceConfig`, `MongoServiceConfig`, `ComposeConfig`).
+
+### `devstack gen` path
+
+`runGenerateConfig` iterates `config.services`, looks up each service key in a **registry map** (`serviceGenerators: Record<string, fn>`), and delegates to `src/addServices/add*Service.ts`. Each `add*Service` function receives the full config and a mutable `ComposeConfig` object, and appends its service block (and any named volumes) directly onto `composeConfig.services` / `composeConfig.volumes`. The final object is serialised to YAML and written to `docker-compose.devstack.yml`.
+
+### Adding a new service
+
+1. Add a new interface to `src/models/devstack-config.ts` and extend `DevStackServices`.
+2. Create `src/addServices/add<Name>Service.ts` — implements `(config, composeConfig) => void`.
+3. Register it in the `serviceGenerators` map in `src/functions/runGenerateConfig.ts`.
+4. Create `src/functions/runAdd<Name>Config.ts` — reads config, sets defaults, calls `writeConfig`.
+5. Wire up the `addCommand.command('<name>')` subcommand in `src/index.ts`.
+
+### Build output
+
+`tsup` compiles everything to a single `dist/index.cjs` (CommonJS). The `bin` field in `package.json` points there. Source uses ESM (`"type": "module"`) with `.js` import extensions on all relative imports (required by `moduleResolution: nodenext`).

--- a/package-lock.json
+++ b/package-lock.json
@@ -1104,9 +1104,9 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -1450,9 +1450,9 @@
       "license": "MIT"
     },
     "node_modules/yaml": {
-      "version": "2.8.2",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.2.tgz",
-      "integrity": "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==",
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
+      "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
       "license": "ISC",
       "bin": {
         "yaml": "bin.mjs"

--- a/src/addServices/addElasticsearchService.ts
+++ b/src/addServices/addElasticsearchService.ts
@@ -1,0 +1,27 @@
+import type { DevStackConfig, ComposeConfig } from "../models/devstack-config.js";
+import { addNamedVolume } from "../utils/config.js";
+
+export function addElasticsearchService(config: DevStackConfig, composeConfig: ComposeConfig): void {
+    const es = config.services.elasticsearch;
+    if (!es?.enabled) return;
+
+    const environment: Record<string, string> = {
+        'discovery.type': 'single-node',
+        ES_JAVA_OPTS: '-Xms512m -Xmx512m',
+        'xpack.security.enabled': es.password ? 'true' : 'false',
+        ...(es.password ? { ELASTIC_PASSWORD: es.password } : {}),
+    };
+
+    composeConfig.services.elasticsearch = {
+        image: es.image,
+        container_name: es.containerName,
+        ports: es.port ? [`${es.port}:9200`] : undefined,
+        environment,
+        ...(es.volume ? { volumes: ['es_data:/usr/share/elasticsearch/data'] } : {}),
+        ...(es.restart ? { restart: es.restart } : {}),
+    };
+
+    if (es.volume) {
+        addNamedVolume(composeConfig, 'es_data');
+    }
+}

--- a/src/addServices/addMailpitService.ts
+++ b/src/addServices/addMailpitService.ts
@@ -1,0 +1,23 @@
+import type { DevStackConfig, ComposeConfig } from "../models/devstack-config.js";
+import { addNamedVolume } from "../utils/config.js";
+
+export function addMailpitService(config: DevStackConfig, composeConfig: ComposeConfig): void {
+    const mailpit = config.services.mailpit;
+    if (!mailpit?.enabled) return;
+
+    const ports: string[] = [];
+    if (mailpit.smtpPort) ports.push(`${mailpit.smtpPort}:1025`);
+    if (mailpit.uiPort) ports.push(`${mailpit.uiPort}:8025`);
+
+    composeConfig.services.mailpit = {
+        image: mailpit.image,
+        container_name: mailpit.containerName,
+        ports: ports.length > 0 ? ports : undefined,
+        ...(mailpit.volume ? { volumes: ['mailpit_data:/data'], environment: { MP_DATA_FILE: '/data/mailpit.db' } } : {}),
+        ...(mailpit.restart ? { restart: mailpit.restart } : {}),
+    };
+
+    if (mailpit.volume) {
+        addNamedVolume(composeConfig, 'mailpit_data');
+    }
+}

--- a/src/addServices/addMinIOService.ts
+++ b/src/addServices/addMinIOService.ts
@@ -1,0 +1,28 @@
+import type { DevStackConfig, ComposeConfig } from "../models/devstack-config.js";
+import { addNamedVolume } from "../utils/config.js";
+
+export function addMinIOService(config: DevStackConfig, composeConfig: ComposeConfig): void {
+    const minio = config.services.minio;
+    if (!minio?.enabled) return;
+
+    const ports: string[] = [];
+    if (minio.port) ports.push(`${minio.port}:9000`);
+    if (minio.consolePort) ports.push(`${minio.consolePort}:9001`);
+
+    composeConfig.services.minio = {
+        image: minio.image,
+        container_name: minio.containerName,
+        ports: ports.length > 0 ? ports : undefined,
+        environment: {
+            MINIO_ROOT_USER: minio.rootUser,
+            MINIO_ROOT_PASSWORD: minio.rootPassword,
+        },
+        command: 'server /data --console-address ":9001"',
+        ...(minio.volume ? { volumes: ['minio_data:/data'] } : {}),
+        ...(minio.restart ? { restart: minio.restart } : {}),
+    };
+
+    if (minio.volume) {
+        addNamedVolume(composeConfig, 'minio_data');
+    }
+}

--- a/src/addServices/addMongoService.ts
+++ b/src/addServices/addMongoService.ts
@@ -1,6 +1,5 @@
 import type { DevStackConfig, ComposeConfig } from "../models/devstack-config.js";
-
-
+import { addNamedVolume } from "../utils/config.js";
 
 export function addMongoService(config: DevStackConfig, composeConfig: ComposeConfig): void {
     const mongo = config.services.mongo;
@@ -8,6 +7,7 @@ export function addMongoService(config: DevStackConfig, composeConfig: ComposeCo
 
     composeConfig.services.mongo = {
         image: mongo.image,
+        container_name: mongo.containerName,
         ports: mongo.port ? [`${mongo.port}:27017`] : undefined,
         environment: {
             MONGO_INITDB_ROOT_USERNAME: mongo.username,
@@ -15,14 +15,10 @@ export function addMongoService(config: DevStackConfig, composeConfig: ComposeCo
             MONGO_INITDB_DATABASE: mongo.database,
         },
         ...(mongo.volume ? { volumes: ['mongo_data:/data/db'] } : {}),
+        ...(mongo.restart ? { restart: mongo.restart } : {}),
     };
 
-    // Add volume definition if volume is enabled
     if (mongo.volume) {
-        composeConfig.volumes = {
-            ...(composeConfig.volumes || {}),
-            mongo_data: {},
-        };
+        addNamedVolume(composeConfig, 'mongo_data');
     }
-
 }

--- a/src/addServices/addMySQLService.ts
+++ b/src/addServices/addMySQLService.ts
@@ -1,0 +1,25 @@
+import type { DevStackConfig, ComposeConfig } from "../models/devstack-config.js";
+import { addNamedVolume } from "../utils/config.js";
+
+export function addMySQLService(config: DevStackConfig, composeConfig: ComposeConfig): void {
+    const mysql = config.services.mysql;
+    if (!mysql?.enabled) return;
+
+    composeConfig.services.mysql = {
+        image: mysql.image,
+        container_name: mysql.containerName,
+        ports: mysql.port ? [`${mysql.port}:3306`] : undefined,
+        environment: {
+            MYSQL_ROOT_PASSWORD: mysql.rootPassword,
+            MYSQL_USER: mysql.username,
+            MYSQL_PASSWORD: mysql.password,
+            MYSQL_DATABASE: mysql.database,
+        },
+        ...(mysql.volume ? { volumes: ['mysql_data:/var/lib/mysql'] } : {}),
+        ...(mysql.restart ? { restart: mysql.restart } : {}),
+    };
+
+    if (mysql.volume) {
+        addNamedVolume(composeConfig, 'mysql_data');
+    }
+}

--- a/src/addServices/addPostgresService.ts
+++ b/src/addServices/addPostgresService.ts
@@ -1,29 +1,24 @@
 import type { ComposeConfig, DevStackConfig } from "../models/devstack-config.js";
-
-
+import { addNamedVolume } from "../utils/config.js";
 
 export function addPostgresService(config: DevStackConfig, composeConfig: ComposeConfig): void {
-  const postgres = config.services?.postgres;
-  if (!postgres?.enabled) return;
+    const postgres = config.services?.postgres;
+    if (!postgres?.enabled) return;
 
-  composeConfig.services.postgres = {
-    image: postgres.image,
-    ports: postgres.port ? [`${postgres.port}:5432`] : undefined,
-    environment: {
-      POSTGRES_USER: postgres.username,
-      POSTGRES_PASSWORD: postgres.password,
-      POSTGRES_DB: postgres.database,
-    },
-    ...(postgres.volume ? { volumes: ['postgres_data:/var/lib/postgresql/data'] } : {}),
-  };
+    composeConfig.services.postgres = {
+        image: postgres.image,
+        container_name: postgres.containerName,
+        ports: postgres.port ? [`${postgres.port}:5432`] : undefined,
+        environment: {
+            POSTGRES_USER: postgres.username,
+            POSTGRES_PASSWORD: postgres.password,
+            POSTGRES_DB: postgres.database,
+        },
+        ...(postgres.volume ? { volumes: ['postgres_data:/var/lib/postgresql/data'] } : {}),
+        ...(postgres.restart ? { restart: postgres.restart } : {}),
+    };
 
-  // Add volume definition if volume is enabled
-  if(postgres.volume) {
-        composeConfig.volumes = {
-            ...(composeConfig.volumes || {}),
-            postgres_data: {},
-        };
+    if (postgres.volume) {
+        addNamedVolume(composeConfig, 'postgres_data');
     }
-
-
 }

--- a/src/addServices/addRabbitMQService.ts
+++ b/src/addServices/addRabbitMQService.ts
@@ -1,0 +1,27 @@
+import type { DevStackConfig, ComposeConfig } from "../models/devstack-config.js";
+import { addNamedVolume } from "../utils/config.js";
+
+export function addRabbitMQService(config: DevStackConfig, composeConfig: ComposeConfig): void {
+    const rabbitmq = config.services.rabbitmq;
+    if (!rabbitmq?.enabled) return;
+
+    const ports: string[] = [];
+    if (rabbitmq.port) ports.push(`${rabbitmq.port}:5672`);
+    if (rabbitmq.managementPort) ports.push(`${rabbitmq.managementPort}:15672`);
+
+    composeConfig.services.rabbitmq = {
+        image: rabbitmq.image,
+        container_name: rabbitmq.containerName,
+        ports: ports.length > 0 ? ports : undefined,
+        environment: {
+            RABBITMQ_DEFAULT_USER: rabbitmq.username,
+            RABBITMQ_DEFAULT_PASS: rabbitmq.password,
+        },
+        ...(rabbitmq.volume ? { volumes: ['rabbitmq_data:/var/lib/rabbitmq'] } : {}),
+        ...(rabbitmq.restart ? { restart: rabbitmq.restart } : {}),
+    };
+
+    if (rabbitmq.volume) {
+        addNamedVolume(composeConfig, 'rabbitmq_data');
+    }
+}

--- a/src/addServices/addRedisService.ts
+++ b/src/addServices/addRedisService.ts
@@ -1,25 +1,22 @@
 import type { DevStackConfig, ComposeConfig } from "../models/devstack-config.js";
+import { addNamedVolume } from "../utils/config.js";
 
-
-
-export function addRedisService(config:DevStackConfig, composeConfig: ComposeConfig): void {
+export function addRedisService(config: DevStackConfig, composeConfig: ComposeConfig): void {
     const redis = config.services.redis;
-    if(!redis?.enabled) return;
+    if (!redis?.enabled) return;
 
     composeConfig.services.redis = {
         image: redis.image,
+        container_name: redis.containerName,
         ports: redis.port ? [`${redis.port}:6379`] : undefined,
-        command: redis.password ? `redis-server --appendonly yes --requirepass ${redis.password}` : "redis-server --appendonly yes",
+        command: redis.password
+            ? `redis-server --appendonly yes --requirepass ${redis.password}`
+            : 'redis-server --appendonly yes',
         ...(redis.volume ? { volumes: ['redis_data:/data'] } : {}),
+        ...(redis.restart ? { restart: redis.restart } : {}),
     };
 
-    
-    // Add volume definition if volume is enabled
-    if(redis.volume) {
-        composeConfig.volumes = {
-            ...(composeConfig.volumes || {}),
-            redis_data: {},
-        };
+    if (redis.volume) {
+        addNamedVolume(composeConfig, 'redis_data');
     }
-
 }

--- a/src/functions/runAddElasticsearchConfig.ts
+++ b/src/functions/runAddElasticsearchConfig.ts
@@ -1,0 +1,41 @@
+import { readConfig, writeConfig } from "../utils/config.js";
+import type { ElasticsearchServiceConfig } from "../models/devstack-config.js";
+
+export function runAddElasticsearchConfig(options: ElasticsearchServiceConfig) {
+    const config = readConfig();
+
+    if (!config.services) {
+        config.services = {};
+    }
+
+    if (config.services.elasticsearch) {
+        console.error("⚠️ Elasticsearch is already configured.");
+        process.exit(1);
+    }
+
+    const port = options.port ? Number(options.port) : 9200;
+
+    if (Number.isNaN(port)) {
+        console.error("⚠️ Invalid port number.");
+        process.exit(1);
+    }
+
+    config.services.elasticsearch = {
+        enabled: true,
+        image: "elasticsearch:8.17.0",
+        containerName: `${config.projectName}_elasticsearch`,
+        port,
+        ...(options.password ? { password: options.password } : {}),
+        volume: true,
+    } as ElasticsearchServiceConfig;
+
+    writeConfig(config);
+    console.log("✅ Elasticsearch added to DevStack\n");
+
+    console.log("----Configuration----");
+    console.log(`  Port:     ${config.services.elasticsearch.port}`);
+    console.log(`  Security: ${options.password ? "enabled" : "disabled (dev mode)"}`);
+    console.log("\nNext steps:");
+    console.log("  devstack gen");
+    console.log("  devstack up");
+}

--- a/src/functions/runAddMailpitConfig.ts
+++ b/src/functions/runAddMailpitConfig.ts
@@ -1,0 +1,42 @@
+import { readConfig, writeConfig } from "../utils/config.js";
+import type { MailpitServiceConfig } from "../models/devstack-config.js";
+
+export function runAddMailpitConfig(options: MailpitServiceConfig) {
+    const config = readConfig();
+
+    if (!config.services) {
+        config.services = {};
+    }
+
+    if (config.services.mailpit) {
+        console.error("⚠️ Mailpit is already configured.");
+        process.exit(1);
+    }
+
+    const smtpPort = options.smtpPort ? Number(options.smtpPort) : 1025;
+    const uiPort = options.uiPort ? Number(options.uiPort) : 8025;
+
+    if (Number.isNaN(smtpPort) || Number.isNaN(uiPort)) {
+        console.error("⚠️ Invalid port number.");
+        process.exit(1);
+    }
+
+    config.services.mailpit = {
+        enabled: true,
+        image: "axllent/mailpit:latest",
+        containerName: `${config.projectName}_mailpit`,
+        smtpPort,
+        uiPort,
+        volume: false,
+    } as MailpitServiceConfig;
+
+    writeConfig(config);
+    console.log("✅ Mailpit added to DevStack\n");
+
+    console.log("----Configuration----");
+    console.log(`  SMTP Port: ${config.services.mailpit.smtpPort}  ← point your app here`);
+    console.log(`  Web UI:    http://localhost:${config.services.mailpit.uiPort}`);
+    console.log("\nNext steps:");
+    console.log("  devstack gen");
+    console.log("  devstack up");
+}

--- a/src/functions/runAddMinIOConfig.ts
+++ b/src/functions/runAddMinIOConfig.ts
@@ -1,0 +1,46 @@
+import { readConfig, writeConfig } from "../utils/config.js";
+import type { MinIOServiceConfig } from "../models/devstack-config.js";
+
+export function runAddMinIOConfig(options: MinIOServiceConfig) {
+    const config = readConfig();
+
+    if (!config.services) {
+        config.services = {};
+    }
+
+    if (config.services.minio) {
+        console.error("⚠️ MinIO is already configured.");
+        process.exit(1);
+    }
+
+    const port = options.port ? Number(options.port) : 9000;
+    const consolePort = options.consolePort ? Number(options.consolePort) : 9001;
+
+    if (Number.isNaN(port) || Number.isNaN(consolePort)) {
+        console.error("⚠️ Invalid port number.");
+        process.exit(1);
+    }
+
+    config.services.minio = {
+        enabled: true,
+        image: "minio/minio:latest",
+        containerName: `${config.projectName}_minio`,
+        port,
+        consolePort,
+        rootUser: options.rootUser || "minioadmin",
+        rootPassword: options.rootPassword || "minioadmin",
+        volume: true,
+    } as MinIOServiceConfig;
+
+    writeConfig(config);
+    console.log("✅ MinIO added to DevStack\n");
+
+    console.log("----Configuration----");
+    console.log(`  API Port:     ${config.services.minio.port}`);
+    console.log(`  Console Port: ${config.services.minio.consolePort}`);
+    console.log(`  Root User:    ${config.services.minio.rootUser}`);
+    console.log("  Console URL:  http://localhost:9001");
+    console.log("\nNext steps:");
+    console.log("  devstack gen");
+    console.log("  devstack up");
+}

--- a/src/functions/runAddMongoConfig.ts
+++ b/src/functions/runAddMongoConfig.ts
@@ -22,7 +22,7 @@ export function runAddMongoConfig(options: MongoServiceConfig) {
 
     config.services.mongo = {
         enabled: true,
-        image: "mongo:latest",
+        image: "mongo:8",
         containerName: `${config.projectName}_mongo`,
         port: port,
         username: options.username || "mongo",

--- a/src/functions/runAddMySQLConfig.ts
+++ b/src/functions/runAddMySQLConfig.ts
@@ -1,0 +1,45 @@
+import { readConfig, writeConfig } from "../utils/config.js";
+import type { MySQLServiceConfig } from "../models/devstack-config.js";
+
+export function runAddMySQLConfig(options: MySQLServiceConfig) {
+    const config = readConfig();
+
+    if (!config.services) {
+        config.services = {};
+    }
+
+    if (config.services.mysql) {
+        console.error("⚠️ MySQL is already configured.");
+        process.exit(1);
+    }
+
+    const port = options.port ? Number(options.port) : 3306;
+
+    if (Number.isNaN(port)) {
+        console.error("⚠️ Invalid port number.");
+        process.exit(1);
+    }
+
+    config.services.mysql = {
+        enabled: true,
+        image: "mysql:8.4",
+        containerName: `${config.projectName}_mysql`,
+        port,
+        rootPassword: options.rootPassword || "rootpassword",
+        username: options.username || "mysql",
+        password: options.password || "mysql",
+        database: options.database || "mysql",
+        volume: true,
+    } as MySQLServiceConfig;
+
+    writeConfig(config);
+    console.log("✅ MySQL added to DevStack\n");
+
+    console.log("----Configuration----");
+    console.log(`  Port:      ${config.services.mysql.port}`);
+    console.log(`  User:      ${config.services.mysql.username}`);
+    console.log(`  Database:  ${config.services.mysql.database}`);
+    console.log("\nNext steps:");
+    console.log("  devstack gen");
+    console.log("  devstack up");
+}

--- a/src/functions/runAddPostgresConfig.ts
+++ b/src/functions/runAddPostgresConfig.ts
@@ -24,7 +24,7 @@ export function runAddPostgresConfig(options:PostgresServiceConfig){
 
     config.services.postgres = {
         enabled: true,
-        image: "postgres:latest",
+        image: "postgres:17",
         containerName: `${config.projectName}_postgres`,
         port: options.port || 5432,
         username: options.username || "postgres",
@@ -41,6 +41,6 @@ export function runAddPostgresConfig(options:PostgresServiceConfig){
         console.log(`  User:      ${config.services.postgres.username}`);
         console.log(`  Database:  ${config.services.postgres.database}`);
         console.log("\nNext steps:");
-        console.log("  devstack generate");
+        console.log("  devstack gen");
         console.log("  devstack up");
  }

--- a/src/functions/runAddRabbitMQConfig.ts
+++ b/src/functions/runAddRabbitMQConfig.ts
@@ -1,0 +1,46 @@
+import { readConfig, writeConfig } from "../utils/config.js";
+import type { RabbitMQServiceConfig } from "../models/devstack-config.js";
+
+export function runAddRabbitMQConfig(options: RabbitMQServiceConfig) {
+    const config = readConfig();
+
+    if (!config.services) {
+        config.services = {};
+    }
+
+    if (config.services.rabbitmq) {
+        console.error("⚠️ RabbitMQ is already configured.");
+        process.exit(1);
+    }
+
+    const port = options.port ? Number(options.port) : 5672;
+    const managementPort = options.managementPort ? Number(options.managementPort) : 15672;
+
+    if (Number.isNaN(port) || Number.isNaN(managementPort)) {
+        console.error("⚠️ Invalid port number.");
+        process.exit(1);
+    }
+
+    config.services.rabbitmq = {
+        enabled: true,
+        image: "rabbitmq:4-management",
+        containerName: `${config.projectName}_rabbitmq`,
+        port,
+        managementPort,
+        username: options.username || "guest",
+        password: options.password || "guest",
+        volume: true,
+    } as RabbitMQServiceConfig;
+
+    writeConfig(config);
+    console.log("✅ RabbitMQ added to DevStack\n");
+
+    console.log("----Configuration----");
+    console.log(`  AMQP Port:       ${config.services.rabbitmq.port}`);
+    console.log(`  Management Port: ${config.services.rabbitmq.managementPort}`);
+    console.log(`  User:            ${config.services.rabbitmq.username}`);
+    console.log("  Management UI:   http://localhost:15672");
+    console.log("\nNext steps:");
+    console.log("  devstack gen");
+    console.log("  devstack up");
+}

--- a/src/functions/runAddRedisConfig.ts
+++ b/src/functions/runAddRedisConfig.ts
@@ -21,10 +21,10 @@ export function runAddRedisConfig(options: RedisServiceConfig){
 
     config.services.redis = {
         enabled: true,
-        image: "redis:latest",
+        image: "redis:7",
         containerName: `${config.projectName}_redis`,
-        port: options.port || 6379,
-        password: options.password || 'redis_password',
+        port: port,
+        password: options.password,
         volume: true,
     } as RedisServiceConfig;
 
@@ -33,4 +33,10 @@ export function runAddRedisConfig(options: RedisServiceConfig){
 
     console.log("----Configuration----");
     console.log(`  Port:      ${config.services.redis.port}`);
+    if (config.services.redis.password) {
+        console.log(`  Password:  set`);
+    }
+    console.log("\nNext steps:");
+    console.log("  devstack gen");
+    console.log("  devstack up");
 }

--- a/src/functions/runDownConfig.ts
+++ b/src/functions/runDownConfig.ts
@@ -1,5 +1,5 @@
 import { spawnSync } from "child_process";
-import { getConfigPath, readConfig } from "../utils/config.js";
+import { readConfig } from "../utils/config.js";
 
 export function runDownConfig(options: { removeVolumes: boolean; removeImages: boolean }) {
     console.log("\n⏹  Stopping DevStack services...\n");
@@ -17,7 +17,6 @@ export function runDownConfig(options: { removeVolumes: boolean; removeImages: b
   }
   const result = spawnSync("docker", args, {
     stdio: "inherit",
-    shell: true
   });
 
   if(result.status !== 0) {
@@ -31,6 +30,7 @@ export function runDownConfig(options: { removeVolumes: boolean; removeImages: b
     ["builder", "prune", "-f"],
     { stdio: "inherit" }
   );
-  process.exit(result.status ?? 0);
+
   console.log("\n✅ DevStack stopped and cleaned successfully.\n");
+  process.exit(result.status ?? 0);
 }

--- a/src/functions/runGenerateConfig.ts
+++ b/src/functions/runGenerateConfig.ts
@@ -5,11 +5,21 @@ import fs from "node:fs";
 import { addPostgresService } from "../addServices/addPostgresService.js";
 import { addRedisService } from "../addServices/addRedisService.js";
 import { addMongoService } from "../addServices/addMongoService.js";
+import { addMySQLService } from "../addServices/addMySQLService.js";
+import { addRabbitMQService } from "../addServices/addRabbitMQService.js";
+import { addElasticsearchService } from "../addServices/addElasticsearchService.js";
+import { addMinIOService } from "../addServices/addMinIOService.js";
+import { addMailpitService } from "../addServices/addMailpitService.js";
 
 const serviceGenerators: Record<string, (config: DevStackConfig, composeConfig: ComposeConfig) => void> = {
     postgres: addPostgresService,
     redis: addRedisService,
     mongo: addMongoService,
+    mysql: addMySQLService,
+    rabbitmq: addRabbitMQService,
+    elasticsearch: addElasticsearchService,
+    minio: addMinIOService,
+    mailpit: addMailpitService,
 };
 
 export function runGenerateConfig() {

--- a/src/functions/runLogsConfig.ts
+++ b/src/functions/runLogsConfig.ts
@@ -1,18 +1,9 @@
-import path from "node:path";
-import fs from "node:fs";
-import { readConfig } from "../utils/config.js";
+import { readConfig, requireComposeFile } from "../utils/config.js";
 import { spawn } from "node:child_process";
 
 export function runLogsConfig(service?: string) {
     const config = readConfig();
-    const composeFileName = config.composeFileName || "docker-compose.devstack.yml";
-    const composePath = path.join(process.cwd(), composeFileName);
-
-    if (!fs.existsSync(composePath)) {
-        console.error(`⚠️ ${composeFileName} not found.`);
-        console.error("Please run `devstack generate` first.");
-        process.exit(1);
-    }
+    const composeFileName = requireComposeFile(config);
 
     const args = ["compose", "-f", composeFileName, "logs", "--follow"];
 

--- a/src/functions/runRestartConfig.ts
+++ b/src/functions/runRestartConfig.ts
@@ -1,18 +1,9 @@
-import path from "node:path";
-import fs from "node:fs";
-import { readConfig } from "../utils/config.js";
+import { readConfig, requireComposeFile } from "../utils/config.js";
 import { spawnSync } from "node:child_process";
 
 export function runRestartConfig(service?: string) {
     const config = readConfig();
-    const composeFileName = config.composeFileName || "docker-compose.devstack.yml";
-    const composePath = path.join(process.cwd(), composeFileName);
-
-    if (!fs.existsSync(composePath)) {
-        console.error(`⚠️ ${composeFileName} not found.`);
-        console.error("Please run `devstack generate` first.");
-        process.exit(1);
-    }
+    const composeFileName = requireComposeFile(config);
 
     const args = ["compose", "-f", composeFileName, "restart"];
 

--- a/src/functions/runStatusConfig.ts
+++ b/src/functions/runStatusConfig.ts
@@ -1,18 +1,9 @@
-import path from "node:path";
-import fs from "node:fs";
-import { readConfig } from "../utils/config.js";
+import { readConfig, requireComposeFile } from "../utils/config.js";
 import { spawnSync } from "node:child_process";
 
 export function runStatusConfig(service?: string) {
     const config = readConfig();
-    const composeFileName = config.composeFileName || "docker-compose.devstack.yml";
-    const composePath = path.join(process.cwd(), composeFileName);
-
-    if (!fs.existsSync(composePath)) {
-        console.error(`⚠️ ${composeFileName} not found.`);
-        console.error("Please run `devstack gen` first.");
-        process.exit(1);
-    }
+    const composeFileName = requireComposeFile(config);
 
     const args = ["compose", "-f", composeFileName, "ps"];
 

--- a/src/functions/runUpConfig.ts
+++ b/src/functions/runUpConfig.ts
@@ -1,6 +1,4 @@
-import path from "node:path";
-import fs from "node:fs";
-import { writeConfig, readConfig } from "../utils/config.js";
+import { readConfig, requireComposeFile } from "../utils/config.js";
 import { spawnSync } from "node:child_process";
 
 export interface UpOptions {
@@ -10,13 +8,7 @@ export interface UpOptions {
 
 export function runUpConfig(options: UpOptions = {}) {
     const config = readConfig();
-    const composeFileName = config.composeFileName || "docker-compose.devstack.yml";
-    const composePath = path.join(process.cwd(), composeFileName);
-    if (!fs.existsSync(composePath)) {
-        console.error(`⚠️ ${composeFileName} not found.`);
-        console.error("Please run `devstack generate` first.");
-        process.exit(1);
-    }
+    const composeFileName = requireComposeFile(config);
 
     const args = ["compose", "-f", composeFileName, "up" , '-d'];
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,13 +7,18 @@ import { createDevstackConfig } from './functions/createDevstackConfig.js';
 import { runAddPostgresConfig } from './functions/runAddPostgresConfig.js';
 import { runGenerateConfig } from './functions/runGenerateConfig.js';
 import { runUpConfig, type UpOptions } from './functions/runUpConfig.js';
-import type { PostgresServiceConfig, RedisServiceConfig, MongoServiceConfig } from './models/devstack-config.js';
+import type { PostgresServiceConfig, RedisServiceConfig, MongoServiceConfig, MySQLServiceConfig, RabbitMQServiceConfig, ElasticsearchServiceConfig, MinIOServiceConfig, MailpitServiceConfig } from './models/devstack-config.js';
 import { runDownConfig } from './functions/runDownConfig.js';
 import { runLogsConfig } from './functions/runLogsConfig.js';
 import { runStatusConfig } from './functions/runStatusConfig.js';
 import { runRestartConfig } from './functions/runRestartConfig.js';
 import { runAddRedisConfig } from './functions/runAddRedisConfig.js';
 import { runAddMongoConfig } from './functions/runAddMongoConfig.js';
+import { runAddMySQLConfig } from './functions/runAddMySQLConfig.js';
+import { runAddRabbitMQConfig } from './functions/runAddRabbitMQConfig.js';
+import { runAddElasticsearchConfig } from './functions/runAddElasticsearchConfig.js';
+import { runAddMinIOConfig } from './functions/runAddMinIOConfig.js';
+import { runAddMailpitConfig } from './functions/runAddMailpitConfig.js';
 
 
 const program = new Command();
@@ -67,7 +72,7 @@ addCommand
 .command('postgres')
 .description('Add a PostgreSQL service to your DevStack project')
 .option('-p, --port <port>', 'Port to expose PostgreSQL on', '5432')
-.option('-u, --user <user>', 'PostgreSQL username', 'postgres')
+.option('-u, --username <username>', 'PostgreSQL username', 'postgres')
 .option('-P, --password <password>', 'PostgreSQL password', 'postgres')
 .option('-d, --database <database>', 'PostgreSQL database name', 'postgres')
 .action((options: PostgresServiceConfig) => {
@@ -92,6 +97,58 @@ addCommand
 .option('-d, --database <database>', 'MongoDB database name', 'mongo')
 .action((options: MongoServiceConfig) => {
   runAddMongoConfig(options);
+});
+
+addCommand
+.command('mysql')
+.description('Add a MySQL service to your DevStack project')
+.option('-p, --port <port>', 'Port to expose MySQL on', '3306')
+.option('-R, --root-password <rootPassword>', 'MySQL root password', 'rootpassword')
+.option('-u, --username <username>', 'MySQL username', 'mysql')
+.option('-P, --password <password>', 'MySQL password', 'mysql')
+.option('-d, --database <database>', 'MySQL database name', 'mysql')
+.action((options: MySQLServiceConfig) => {
+  runAddMySQLConfig(options);
+});
+
+addCommand
+.command('rabbitmq')
+.description('Add a RabbitMQ service to your DevStack project')
+.option('-p, --port <port>', 'AMQP port', '5672')
+.option('-m, --management-port <managementPort>', 'Management UI port', '15672')
+.option('-u, --username <username>', 'RabbitMQ username', 'guest')
+.option('-P, --password <password>', 'RabbitMQ password', 'guest')
+.action((options: RabbitMQServiceConfig) => {
+  runAddRabbitMQConfig(options);
+});
+
+addCommand
+.command('elasticsearch')
+.description('Add an Elasticsearch service to your DevStack project')
+.option('-p, --port <port>', 'Port to expose Elasticsearch on', '9200')
+.option('-P, --password <password>', 'Elastic password (enables security when set)')
+.action((options: ElasticsearchServiceConfig) => {
+  runAddElasticsearchConfig(options);
+});
+
+addCommand
+.command('minio')
+.description('Add a MinIO (S3-compatible storage) service to your DevStack project')
+.option('-p, --port <port>', 'API port', '9000')
+.option('-c, --console-port <consolePort>', 'Web console port', '9001')
+.option('-u, --root-user <rootUser>', 'Root user', 'minioadmin')
+.option('-P, --root-password <rootPassword>', 'Root password', 'minioadmin')
+.action((options: MinIOServiceConfig) => {
+  runAddMinIOConfig(options);
+});
+
+addCommand
+.command('mailpit')
+.description('Add a Mailpit local SMTP catcher to your DevStack project')
+.option('-p, --smtp-port <smtpPort>', 'SMTP port your app sends to', '1025')
+.option('-u, --ui-port <uiPort>', 'Web UI port to inspect emails', '8025')
+.action((options: MailpitServiceConfig) => {
+  runAddMailpitConfig(options);
 });
 
 

--- a/src/models/devstack-config.ts
+++ b/src/models/devstack-config.ts
@@ -1,11 +1,23 @@
-export interface PostgresServiceConfig{
-    enabled:boolean;
-    image:string;
-    containerName:string;
-    port:string;
-    username:string;
-    password:string;
-    database:string;
+export interface PostgresServiceConfig {
+    enabled: boolean;
+    image: string;
+    containerName: string;
+    port: string;
+    username: string;
+    password: string;
+    database: string;
+    volume: boolean;
+    volumeName?: string;
+    restart?: "no" | "always" | "unless-stopped" | "on-failure";
+    healthcheck?: boolean;
+}
+
+export interface RedisServiceConfig {
+    enabled: boolean;
+    image: string;
+    containerName: string;
+    port: number;
+    password?: string;
     volume: boolean;
     volumeName?: string;
     restart?: "no" | "always" | "unless-stopped" | "on-failure";
@@ -26,34 +38,87 @@ export interface MongoServiceConfig {
     healthcheck?: boolean;
 }
 
+export interface MySQLServiceConfig {
+    enabled: boolean;
+    image: string;
+    containerName: string;
+    port: number;
+    rootPassword: string;
+    username: string;
+    password: string;
+    database: string;
+    volume: boolean;
+    volumeName?: string;
+    restart?: "no" | "always" | "unless-stopped" | "on-failure";
+}
+
+export interface RabbitMQServiceConfig {
+    enabled: boolean;
+    image: string;
+    containerName: string;
+    port: number;
+    managementPort: number;
+    username: string;
+    password: string;
+    volume: boolean;
+    volumeName?: string;
+    restart?: "no" | "always" | "unless-stopped" | "on-failure";
+}
+
+export interface ElasticsearchServiceConfig {
+    enabled: boolean;
+    image: string;
+    containerName: string;
+    port: number;
+    password?: string;
+    volume: boolean;
+    volumeName?: string;
+    restart?: "no" | "always" | "unless-stopped" | "on-failure";
+}
+
+export interface MinIOServiceConfig {
+    enabled: boolean;
+    image: string;
+    containerName: string;
+    port: number;
+    consolePort: number;
+    rootUser: string;
+    rootPassword: string;
+    volume: boolean;
+    volumeName?: string;
+    restart?: "no" | "always" | "unless-stopped" | "on-failure";
+}
+
+export interface MailpitServiceConfig {
+    enabled: boolean;
+    image: string;
+    containerName: string;
+    smtpPort: number;
+    uiPort: number;
+    volume: boolean;
+    volumeName?: string;
+    restart?: "no" | "always" | "unless-stopped" | "on-failure";
+}
+
 export interface DevStackServices {
     postgres?: PostgresServiceConfig;
     redis?: RedisServiceConfig;
     mongo?: MongoServiceConfig;
+    mysql?: MySQLServiceConfig;
+    rabbitmq?: RabbitMQServiceConfig;
+    elasticsearch?: ElasticsearchServiceConfig;
+    minio?: MinIOServiceConfig;
+    mailpit?: MailpitServiceConfig;
 }
-
 
 export interface DevStackConfig {
-  projectName: string;
-  version: string;
-  composeFileName: string;
-  services: DevStackServices;
-}
-
-
-export interface RedisServiceConfig {
-  enabled: boolean;
-  image: string;
-  containerName: string;
-  port: number;
-  password?: string;
-  volume: boolean;
-  volumeName?: string;
-  restart?: "no" | "always" | "unless-stopped" | "on-failure";
-  healthcheck?: boolean;
+    projectName: string;
+    version: string;
+    composeFileName: string;
+    services: DevStackServices;
 }
 
 export type ComposeConfig = {
-  services: Record<string, any>;
-  volumes?: Record<string, any>;
+    services: Record<string, any>;
+    volumes?: Record<string, any>;
 };

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -1,5 +1,5 @@
-import fs, { readFileSync } from "node:fs";
-import type { DevStackConfig } from "../models/devstack-config.js";
+import fs from "node:fs";
+import type { ComposeConfig, DevStackConfig } from "../models/devstack-config.js";
 import path from "node:path";
 import YAML from "yaml";
 
@@ -7,16 +7,14 @@ export function getConfigPath(): string {
   return path.join(process.cwd(), "devstack.config.json");
 }
 
-
-export function readConfig():DevStackConfig{
-    const configPath = getConfigPath();
-    if(!fs.existsSync(configPath)) {
-        console.error("No devstack.config.json found in the current directory.");
-        process.exit(1);
-    }
-
-    const raw = fs.readFileSync(configPath, "utf-8");
-    return JSON.parse(raw) as DevStackConfig;
+export function readConfig(): DevStackConfig {
+  const configPath = getConfigPath();
+  if (!fs.existsSync(configPath)) {
+    console.error("No devstack.config.json found in the current directory.");
+    process.exit(1);
+  }
+  const raw = fs.readFileSync(configPath, "utf-8");
+  return JSON.parse(raw) as DevStackConfig;
 }
 
 export function writeConfig(config: DevStackConfig): void {
@@ -24,7 +22,21 @@ export function writeConfig(config: DevStackConfig): void {
   fs.writeFileSync(configPath, `${JSON.stringify(config, null, 2)}\n`, "utf-8");
 }
 
-export function convertToYAML(obj: any): any {
+export function convertToYAML(obj: any): string {
   return YAML.stringify(obj);
+}
+
+export function requireComposeFile(config: DevStackConfig): string {
+  const composeFileName = config.composeFileName ?? "docker-compose.devstack.yml";
+  const composePath = path.join(process.cwd(), composeFileName);
+  if (!fs.existsSync(composePath)) {
+    console.error(`⚠️ ${composeFileName} not found. Please run \`devstack gen\` first.`);
+    process.exit(1);
+  }
+  return composeFileName;
+}
+
+export function addNamedVolume(composeConfig: ComposeConfig, name: string): void {
+  composeConfig.volumes = { ...(composeConfig.volumes ?? {}), [name]: {} };
 }
 


### PR DESCRIPTION
New services: MySQL, RabbitMQ, Elasticsearch, MinIO, Mailpit. Each follows the same service registry pattern — model interface, addService generator, runAddConfig function, and commander subcommand.

Shared utilities:
- requireComposeFile() in utils/config.ts replaces the duplicated compose-file existence check across four run functions
- addNamedVolume() in utils/config.ts replaces the duplicated volume merge spread in every addService file

Improvements to existing services:
- container_name and restart fields now written to compose output (were stored in config but silently dropped by all generators)
- Default images pinned: redis:latest → redis:7, mongo:latest → mongo:8
- Postgres --user flag renamed to --username to match the model interface (options.username was always undefined at runtime)
- runAddRedisConfig: saved options.port (string) instead of the validated port (number); password no longer defaults to a hardcoded string when the field is optional; Next steps output added
- runDownConfig: success log was unreachable (after process.exit), removed unused getConfigPath import, removed unnecessary shell:true
- Next steps in runAddPostgresConfig corrected to devstack gen